### PR TITLE
Added support for mitmproxy insecure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ First of all, you have to create a configuration file `/usr/share/PiRanha/.confi
 host = http://localhost:8081
 token = my_PiPrecious_access_token
 iface = wlan1
+mitmproxy_insecure = true
 ```
+
+*mitmproxy_insecure* makes mitmproxy accept upstream TLS connections even if certificate is invalid or selfsigned
 
 ### Register a smartphone
 ```

--- a/piranha/network.py
+++ b/piranha/network.py
@@ -14,9 +14,10 @@ class TCPDumpConfig:
 
 
 class MITMProxyConfig:
-    def __init__(self, flow_output, port = 8080):
+    def __init__(self, flow_output, port = 8080, insecure=False):
         self.flow_output = flow_output
         self.port = port
+        self.insecure = insecure
 
 
 class TCPDump:
@@ -45,7 +46,8 @@ class MITMProxy:
         self.p_mitmproxy = None
 
     def start(self):
-        cmd = "mitmdump --anticomp --mode transparent -w %s" % self.config.flow_output
+        insecure_mode = "--ssl-insecure" if self.config.insecure else ""
+        cmd = "mitmdump --anticomp --mode transparent {insecure} -w {output}".format(output=self.config.flow_output, insecure=insecure_mode)
         self.p_mitmproxy = sp.Popen(cmd, stdout = sp.PIPE, shell = True, preexec_fn = os.setsid)
         time.sleep(5)
 

--- a/piranha/piranha.py
+++ b/piranha/piranha.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
 
     auth_token = config['DEFAULT']['token']
     network_interface = config['DEFAULT']['iface']
-
+    mitmproxy_insecure = config['DEFAULT'].get('mitmproxy_insecure', "false") == "true"
     p = PiRanha(config['DEFAULT']['host'], auth_token)
 
     adb = ADB(options.adb_path)
@@ -67,7 +67,7 @@ if __name__ == '__main__':
             # Prepare mitmproxy
             flow_name = '%s.flow' % session['id']
             flow_path = os.path.join(tmp, flow_name)
-            mitmproxy_configuration = MITMProxyConfig(flow_path)
+            mitmproxy_configuration = MITMProxyConfig(flow_path, insecure=mitmproxy_insecure)
             mitmproxy = MITMProxy(mitmproxy_configuration)
             # Start network capture
             p.start_tranparent_routing()


### PR DESCRIPTION
This mode makes mitmproxy accept insecure tls connections (self signed or invalid certificates)

This is useful to intercept trafic from those servers